### PR TITLE
Update README's and add scripts for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,20 @@
 # JemBijoux's .dotfiles
 
-As I do more work with the command line it's making more and more sense to put 
-some of the configuration into a dotfiles repo so that I can refer to it later.
-Also I've started playing more with `vim` and would like to save my progress
-(wrt configuration etc). 
+Working with shells in multiple places, I've come to collect some configuration
+that I might want to share between systems. Those config are stored in this repo.
 
-This is all a work in progress... (but at least it's versioned and saved)
+See the readme in a specific sub-directory for details related to that
+application...
 
-## .vimrc
-Basic vim configuration
+- [Vim](./vim/README.md)
+- [Tmux](./tmux/README.md)
+- [ZSH](./zsh/README.md)
+- [npm](./npm/README.md)
 
-Install: $  `ln -s ~/.dotfiles/.vim ~`
-Color theme: One Dark
+## Installation
 
-### Plugins
-
-- nerdtree: a simple file browser sidebar
-- syntastic: syntax highlighting (haven't figured it out yet)
-- vim-airline: A nice status bar for vim
-- vim-gitgutter: shows git changes in the gutter
-- vim-fugitive: lot's of git controls
-- command-t: quick fuzzyfinder opener for files
-  Had problems installing this because of compilationg problems.
-  Just needed to ensure ruby was installed with disable binary, and then
-  reinstalled vim. 
-  (Details: https://github.com/rvm/rvm/issues/3360#issuecomment-87340953)
-
-*Plugins are now installed as git submodules*
-
-There's information on this 
-[vim-casts](http://vimcasts.org/episodes/synchronizing-plugins-with-git-submodules-and-pathogen/)
-post about how to do this, but essentially it comes down to a simple git
-command to pull in all the submodules.
-
-```
-git submodule update --init
-```
+1. Start by cloning the dotfiles repo (typically to your home folder). Because
+   the folder itself starts with a dot, it will be invisible by default.
+2. Run `~/.dotfiles/link-all.sh` which will automatically create symlinks for
+   all of the dotfile directories at once.
+3. You can also just run the `install-link.sh` in any of the subfolders.

--- a/install-links.sh
+++ b/install-links.sh
@@ -1,0 +1,3 @@
+./vim/install-link.sh
+./zsh/install-link.sh
+./tmux/install-link.sh

--- a/tmux/install-link.sh
+++ b/tmux/install-link.sh
@@ -1,0 +1,1 @@
+ln -s ~/.dotfiles/tmux/tmux.conf ~/.tmux.conf

--- a/vim/README.md
+++ b/vim/README.md
@@ -1,0 +1,31 @@
+# VIM Configuration
+
+This is where the vim configuration lives. To install these dotfiles, all you
+have to do is run the `install-link.sh` within this vim folder and we'll
+automatically symlink them into the right spot.
+
+```sh
+ln -s ~/.dotfiles/vim/ ~/.vim
+```
+
+## Split Configuration
+
+Because vim configuration can become quite large, I've split it up into a
+couple of different files. There is one `extensions.vim` that contains
+information related to plugins. `keybindings.vim` has everythink keyboard
+related.
+
+## Plugins
+
+Vim plugins are all managed by [vim-plug](). Once vim is running and the
+dotfiles have been sourced, you can `:PlugInstall` to pull everything down.
+
+### Specific Plugins:
+
+- vim-fugitive: makes git stuff way more manageable
+- vim-gitgutter: shows git markers in gutter
+- vim-commentary: easier comment controls
+- ale: a linting engine
+- ultisnips: and vim-snippets
+- nerdtree: file browsing
+- easymotion: double-leader for quick navigation

--- a/vim/install-link.sh
+++ b/vim/install-link.sh
@@ -1,0 +1,1 @@
+ln -s ~/.dotfiles/vim ~/.vim

--- a/vim/vim
+++ b/vim/vim
@@ -1,0 +1,1 @@
+/home/jam/.dotfiles/vim

--- a/zsh/install-link.sh
+++ b/zsh/install-link.sh
@@ -1,0 +1,1 @@
+ln -s ~/.dotfiles/zsh/zshrc ~/.zshrc


### PR DESCRIPTION
The readme files contained some out of date information, and shell
scripts make it easier to link them on a new system.

- Update install-link.sh to add the appropriate symlinks
- Remove some notes that mentioned git submodules
- Add a README in the vim section to hold some vim specific comments